### PR TITLE
110 popup stays stationary when the marker moves

### DIFF
--- a/components/VueLayerMap.vue
+++ b/components/VueLayerMap.vue
@@ -23,7 +23,7 @@
 <script lang="ts">
 import { defineComponent } from "vue";
 import View from "ol/View";
-import { fromLonLat, toLonLat } from "ol/proj";
+import { fromLonLat } from "ol/proj";
 import { eventBus } from "~/plugins/utils";
 
 interface Properties {
@@ -95,28 +95,10 @@ export default defineComponent({
          * TODO - try to figure out a way to hide the selected style until this onselect function is triggered to update the icon
          */
         positionInfo.id.includes("sp_") ? this.selectIconSrc = "/phone-selected.png" : this.selectIconSrc = "/marker-selected.png";
-        // convert timestamp to readable format
-        const timestamp : Date = new Date(positionInfo.timestamp * 1000);
-        const tsString : string = timestamp.toLocaleString();
-        /*
-         * WARNING: the needed coordinates are regular long/lat (°N °E)
-         * BE SURE TO CONVERT
-         */
-        const markerCoords : Array<number> = e.feature.getGeometry().getCoordinates();
-        const lonlat = toLonLat(markerCoords);
-        const details = Object.fromEntries(Object.entries({
-          ID: positionInfo.id,
-          Longitude: positionInfo.longitude,
-          Latitude: positionInfo.latitude,
-          "Battery Level": positionInfo.batteryLevel,
-          "Last Received Data": tsString
-        }).filter(([_key, value]) => value));
-        if (positionInfo.movementStatus) {
-          details.Moving = undefined;
-        }
+        const lonlat = [positionInfo.longitude, positionInfo.latitude];
         // smooth zoom into tracker location
         eventBus.$emit("centerMapOnTrackedAsset", lonlat);
-        this.$root.$emit("popup-toggled", lonlat, details, positionInfo.alarmEvent, device?.name);
+        this.$root.$emit("popup-toggled", positionInfo, device?.name);
       },
       onDeselect () {
         this.$root.$emit("popup-hide");

--- a/components/VueLayerMarker.vue
+++ b/components/VueLayerMarker.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <vl-feature :properties="{details, device}">
-      <vl-geom-point :coordinates="coordinates" />
+      <vl-geom-point :coordinates="position" />
       <vl-style>
         <vl-style-icon
           :src="iconSrc"
@@ -15,13 +15,14 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from "vue";
+import { eventBus } from "~/plugins/utils";
 
 export default defineComponent({
     name: "VueLayerMarker",
     props: {
         coordinates: {
             type: Array,
-            required: true
+            default: () => [0, 0]
         },
         src: {
             type: String,
@@ -47,8 +48,23 @@ export default defineComponent({
     emits: ["popup-toggled"],
     data () {
       return {
-        iconSrc: this.src
+        iconSrc: this.src,
+        position: this.coordinates
       };
+    },
+    mounted () {
+      /**
+       * when any coordinates are updated, we check if the updated data is linked to the current marker.
+       * If it is, and we're displaying the popup, we also need to update its location.
+       * This happens faster than receiving the new location through our v-for loop in the Index
+       */
+      eventBus.$on("newCoordinates", (data: Position) => {
+        if (this.details) {
+          if (this.details.id === data.id) {
+            this.position = [data.longitude, data.latitude];
+          }
+        }
+      });
     }
 });
 </script>

--- a/components/VueLayerMarkerPopup.vue
+++ b/components/VueLayerMarkerPopup.vue
@@ -21,6 +21,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import { eventBus } from "~/plugins/utils";
 
 export default defineComponent({
     name: "VueLayerMarkerPopup",
@@ -59,6 +60,18 @@ export default defineComponent({
       this.$root.$on("popup-hide", () => {
         this.display = false;
         this.position = [0, 0];
+      });
+      /**
+       * when any coordinates are updated, we check if the updated data is linked to the current popup.
+       * If it is, and we're displaying the popup, we also need to update its
+       * TODO find out why this updates more often/more quickly than our marker location ?
+       */
+      eventBus.$on("newCoordinates", (data: Position) => {
+        if (this.details && this.display) {
+          if (this.details.ID === data.id) {
+            this.position = [data.longitude, data.latitude];
+          }
+        }
       });
     },
     methods: {

--- a/components/VueLayerMarkerPopup.vue
+++ b/components/VueLayerMarkerPopup.vue
@@ -67,8 +67,25 @@ export default defineComponent({
        */
       eventBus.$on("newCoordinates", (data: Position) => {
         if (this.details && this.display) {
+          // if the data ID is the same as the current popup ID
           if (this.details.ID === data.id) {
+            // We update the position
             this.position = [data.longitude, data.latitude];
+            // convert timestamp to readable format
+            const timestamp : Date = new Date(data.timestamp * 1000);
+            const tsString : string = timestamp.toLocaleString();
+            // update popup details when the attached asset has sent an update
+            const details = Object.fromEntries(Object.entries({
+              ID: data.id,
+              Longitude: data.longitude,
+              Latitude: data.latitude,
+              "Battery Level": data.batteryLevel,
+              "Last Received Data": tsString
+            }).filter(([_key, value]) => value));
+            if (data.movementStatus) {
+              details.Moving = undefined;
+            }
+            this.details = details;
           }
         }
       });

--- a/components/VueLayerMarkerPopup.vue
+++ b/components/VueLayerMarkerPopup.vue
@@ -72,6 +72,11 @@ export default defineComponent({
           }
         }
       });
+      eventBus.$on("removedMarker", (elementID : string) => {
+        if (this.display && this.details.ID === elementID) {
+          this.display = false;
+        }
+      });
     },
     methods: {
       toggleDetails () {}

--- a/components/VueLayerMarkerPopup.vue
+++ b/components/VueLayerMarkerPopup.vue
@@ -50,11 +50,11 @@ export default defineComponent({
         };
     },
     mounted () {
-        this.$root.$on("popup-toggled", (coordinates : Array<number>, details : Object, alarmEvent: boolean, name?: string) => {
+        this.$root.$on("popup-toggled", (positionInfo: Position, name?: string) => {
             this.display = true;
-            this.position = coordinates;
-            this.details = details;
-            this.attention = alarmEvent;
+            this.position = [positionInfo.longitude, positionInfo.latitude];
+            this.details = this.parseDetails(positionInfo);
+            this.attention = !!positionInfo.alarmEvent;
             this.name = name;
       });
       this.$root.$on("popup-hide", () => {
@@ -71,21 +71,8 @@ export default defineComponent({
           if (this.details.ID === data.id) {
             // We update the position
             this.position = [data.longitude, data.latitude];
-            // convert timestamp to readable format
-            const timestamp : Date = new Date(data.timestamp * 1000);
-            const tsString : string = timestamp.toLocaleString();
             // update popup details when the attached asset has sent an update
-            const details = Object.fromEntries(Object.entries({
-              ID: data.id,
-              Longitude: data.longitude,
-              Latitude: data.latitude,
-              "Battery Level": data.batteryLevel,
-              "Last Received Data": tsString
-            }).filter(([_key, value]) => value));
-            if (data.movementStatus) {
-              details.Moving = undefined;
-            }
-            this.details = details;
+            this.details = this.parseDetails(data);
           }
         }
       });
@@ -96,7 +83,23 @@ export default defineComponent({
       });
     },
     methods: {
-      toggleDetails () {}
+      toggleDetails () {},
+      parseDetails (data : Position) {
+        // convert timestamp to readable format
+        const timestamp : Date = new Date(data.timestamp * 1000);
+        const tsString : string = timestamp.toLocaleString();
+        const details = Object.fromEntries(Object.entries({
+              ID: data.id,
+              Longitude: data.longitude,
+              Latitude: data.latitude,
+              "Battery Level": data.batteryLevel,
+              "Last Received Data": tsString
+            }).filter(([_key, value]) => value));
+            if (data.movementStatus) {
+              details.Moving = undefined;
+            }
+            return details;
+      }
     }
 });
 </script>

--- a/components/VueLayerMarkerPopup.vue
+++ b/components/VueLayerMarkerPopup.vue
@@ -63,8 +63,7 @@ export default defineComponent({
       });
       /**
        * when any coordinates are updated, we check if the updated data is linked to the current popup.
-       * If it is, and we're displaying the popup, we also need to update its
-       * TODO find out why this updates more often/more quickly than our marker location ?
+       * If it is, and we're displaying the popup, we also need to update its location.
        */
       eventBus.$on("newCoordinates", (data: Position) => {
         if (this.details && this.display) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -74,7 +74,8 @@ export default Vue.extend({
     setInterval(() => {
       this.positions.forEach((position, index) => {
         if (Math.abs(position.timestamp - Date.now() / 1000) >= 60) {
-          this.positions.splice(index, 1);
+          const removedElement = this.positions.splice(index, 1)[0];
+          eventBus.$emit("removedMarker", (removedElement.id));
         }
       });
     }, 60000);

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,6 +24,7 @@
         <vue-layer-marker
           v-for="position in positions"
           :key="position.id"
+          :coordinates="[position.longitude, position.latitude]"
           :details="position"
           :src="position.id.includes('sp_') ? '/phone.png' : '/marker.png'"
           :select-src="position.id.includes('sp_') ? '/phone-selected.png' : '/marker-selected.png'"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,7 +25,6 @@
           v-for="position in positions"
           :key="position.id"
           :details="position"
-          :coordinates="[position.longitude, position.latitude]"
           :src="position.id.includes('sp_') ? '/phone.png' : '/marker.png'"
           :select-src="position.id.includes('sp_') ? '/phone-selected.png' : '/marker-selected.png'"
           :scale="0.15"


### PR DESCRIPTION
By fixing this, I also improved the marker accuracy by reworking the way the location is updated. 
Now, the markers are listening for an update event, check if it is their ID that updated, and if so, it updates the marker location & the popup location/information, if it is opened on that marker.